### PR TITLE
fix: provide color Shiva Blue if not exists

### DIFF
--- a/src/mtng/template/main.tex
+++ b/src/mtng/template/main.tex
@@ -37,6 +37,7 @@
 \begin{frame}[c]{}
   \begin{center}
     \Large
+    \providecolor{shivablue}{rgb}{0.6,0.86,0.99}
     \color{shivablue}
     \sffamily 
     No merged PRs since \textbf{ {{ last.strftime('%Y-%m-%d') }} } in\\


### PR DESCRIPTION
This allows for pre-existing `shivablue` but defines it if not present.