### PR TITLE
Fix early return bug in `collect_repositories`

### DIFF
--- a/src/mtng/collect.py
+++ b/src/mtng/collect.py
@@ -288,4 +288,4 @@ async def collect_repositories(
                 )
                 data[repo.name]["needs_discussion"] = needs_discussion
 
-        return data
+    return data


### PR DESCRIPTION
I noticed that after updating to mtng 0.7.3 from 0.6.0, it refused to collect data for multiple repositories defined in my configuration YAML file. After some debugging I concluded that the bug is due to a return statement in `collect_repositories` that is indented one level too much, returning from the entire function after the first repository has been fetched, rather than after _all_ repositories are done.